### PR TITLE
Add GitHub Action for Electron builds

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -1,0 +1,33 @@
+name: Electron build
+
+on: push
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: "12"
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+          package_root: clients/electron

--- a/clients/electron/package.json
+++ b/clients/electron/package.json
@@ -79,6 +79,7 @@
 	},
 	"devDependencies": {
 		"electron": "10.1.3",
+		"electron-builder": "^22.9.1",
 		"electron-notarize": "^1.0.0"
 	}
 }


### PR DESCRIPTION
- Add `electron-builder` to `package.json`.
- Use GitHub Action [`samuelmeuli/action-electron-builder@v1`](https://github.com/marketplace/actions/electron-builder-action) to automatically perform Electron builds.
- Currently does not do the MacOS build due to [issues with notarization](https://github.com/marketplace/actions/electron-builder-action#notarization).
- Will handle releases if the [appropriate workflow](https://github.com/marketplace/actions/electron-builder-action#releasing) is followed.